### PR TITLE
Fix typo in unlicense.org link

### DIFF
--- a/UNLICENSE.md
+++ b/UNLICENSE.md
@@ -1,4 +1,4 @@
-THIS CODE IS RELEASED UNDER [THE UNLICENSE](http://unlucense.org)
+THIS CODE IS RELEASED UNDER [THE UNLICENSE](http://unlicense.org)
 ----------------------------------------------------------------------
 
 **This is free and unencumbered software released into the public domain.**


### PR DESCRIPTION
There was a typo in the first line of UNLICENSE.md. It linked to http://unlucense.org/ (which of course doesn't exist!)
