### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 
-error_reporting(E_NONE); //Setting this to E_ALL showed that that cause of not redirecting were few blank lines added in some php files.
+error_reporting(0); //Setting this to E_ALL showed that that cause of not redirecting were few blank lines added in some php files.
 
 $db_config_path = '../application/config/database.php';
 


### PR DESCRIPTION
Line 3 changed from `error_reporting(E_NONE);` to `error_reporting(0);`
**This prevents the notice** :  Use of undefined constant E_NONE - assumed 'E_NONE'  from being displayed on the installer page.
